### PR TITLE
Trigger words & parseLine changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+# Byte-compiled / optimized / DLL files
+*.py[cod]
+*$py.class
+
+# dotenv
+.env
+
+# virtualenv
+venv/
+ENV/

--- a/Main.py
+++ b/Main.py
@@ -1,7 +1,7 @@
-#Copyright © /u/sagiksp 2016, all right reserved.
+#Copyright: Copyright 2016 /u/sagiksp, all right reserved.
 #Seriously, don't be a dick.
 
-import praw, time
+import praw, time, re
 
 #Variables
 
@@ -13,27 +13,26 @@ users = [] #Array of all people that used the bot, and times of use. Format: [[U
 
 yelled = []
 
-Triggers = ['What', 'what', 'WHAT', 'What?', 'what?', 'WHAT?',
-             'Wut', 'wut', 'WUT', 'Wut?', 'wut?', 'WUT?',
-             'Wat', 'wat', 'WAT', 'Wat?', 'wat?', 'WAT?'] #Texts that trigger the bot.
+Triggers = ['what', 'wut', 'wat']
+Triggers += list(word + '?' for word in Triggers) # append ? to the ends of each of the words above
 
 footer = """***
 
 [^^^Beep ^^^boop.](https://np.reddit.com/r/CantHearYouBot/)""" #Text to be in the end of a message
 
 def check_condition(c): #Check the bot condition
-    return (c.body in Triggers) and (not RateLimit(c.author.name)) #Is the comment a trigger, and is the author not rate limited.
+    return (c.body.lower() in Triggers) and (not RateLimit(c.author.name)) #Is the comment a trigger, and is the author not rate limited.
 
 def bot_action(c,r): #Action the bot preforms
     global users
     parent = r.get_info(thing_id=c.parent_id) #get parent comment
+
     if isNotAValidComment(parent): return #If it is a response to a thread, stop.
 
     if parent.author.name == username and parent.body != "In da but": #If parent is bot and comment is not "in da but"
         return
-    
+
     users.append([c.author.name,c.created_utc]) #Add username and time of use to the users list
-    
 
 
     if check_condition(parent): #What What
@@ -42,7 +41,7 @@ def bot_action(c,r): #Action the bot preforms
         except:
             pass
         return
-    
+
     lines = parent.body.split("\n") #Split parent into lines
     total = ""
     for line in lines: #for each line
@@ -52,7 +51,6 @@ def bot_action(c,r): #Action the bot preforms
         print("\n"+total+"\n\n") #Debug
     except:
         return
-    
 
 def findUsersWithName(name): #find all people with username on the users list
     uses = []
@@ -63,7 +61,7 @@ def findUsersWithName(name): #find all people with username on the users list
 
 def getLastTimeOfUse(name): #Get last time a username has used the bot
     return findUsersWithName(name)[-1][1]
-    
+
 def RateLimit(username): #Boolean. if user has used the bot in the last 5 minutes, stop.
     if username == "sagiksp": return False #unlimited testing
     c_time = time.time() #Current time
@@ -72,15 +70,30 @@ def RateLimit(username): #Boolean. if user has used the bot in the last 5 minute
     lastUseTime = getLastTimeOfUse(username) #Latest time of use
     return (c_time - lastUseTime) <= 300 #has the user used the bot in the last 300 seconds (5 minutes)
 
-
 def parseLine(line):
-    #For the gods of python above, please make a switch statement.
-    if line == "": return "\n" 
-    if line[0] ==  "#": return line.upper() + "\n" #If line already bolded, ignore.
-    if line == "***": return "***\n" #If line is *** (Horizontal rule), ignore.
-    if line == "[^^^Beep ^^^boop.](https://np.reddit.com/r/CantHearYouBot/)": return "#[^^^BEEP ^^^BOOP.](https://np.reddit.com/r/CantHearYouBot/)\n" #TODO: Make links work. Currently it capitalizes the link address. A work around for the subreddit link
-    if line == "#[^^^BEEP ^^^BOOP.](https://np.reddit.com/r/CantHearYouBot/)": return line + "\n" #Here too. It's not working. Send help.
-    return "#" + line.upper() + "\n" #For normal lines, bold it and go home.
+    # Some basic parsing rules that bypass the rest of our logic.
+    if line == '' or line == '***': # Restore split newline // Horizontal rule
+        return line + '\n'
+    
+    # Bold the line
+    if line[0] != '#':
+        line = '#' + line
+    
+    # Uppercase the line, all except URLs. Could probably be made more effective?
+    ldata = re.split(r"(\[.*?\]\(.*?\))", line) # this finds reddit markdown URLs, i.e. [google](http://google.com)
+    line = ''
+    for content in ldata:
+        if not content.startswith('['): # typical string
+            content = content.upper()
+        else:
+            # url; so let's break it up a little further and capitalize the title also
+            url_groups = re.search(r"\[(.*)\]\((.*)\)", content)
+            content = '[' + url_groups.group(1).upper() + '](' + url_groups.group(2) + ')'
+        
+        line += content
+    
+    # Finally, return!
+    return line + '\n'
 
 def isNotAValidComment(thing): #Is it not a valid comment
     return hasattr(thing,"domain") #If it has domain, It's a post, so ignore.

--- a/Main.py
+++ b/Main.py
@@ -13,15 +13,14 @@ users = [] #Array of all people that used the bot, and times of use. Format: [[U
 
 yelled = []
 
-Triggers = ['what', 'wut', 'wat']
-Triggers += list(word + '?' for word in Triggers) # append ? to the ends of each of the words above
+Triggers = ('what', 'wut', 'wat')
 
 footer = """***
 
 [^^^Beep ^^^boop.](https://np.reddit.com/r/CantHearYouBot/)""" #Text to be in the end of a message
 
 def check_condition(c): #Check the bot condition
-    return (c.body.lower() in Triggers) and (not RateLimit(c.author.name)) #Is the comment a trigger, and is the author not rate limited.
+    return (c.body.lower().rstrip('?') in Triggers) and (not RateLimit(c.author.name)) #Is the comment a trigger, and is the author not rate limited.
 
 def bot_action(c,r): #Action the bot preforms
     global users


### PR DESCRIPTION
Hi, sagiksp!

I came across your bot and noticed that when it capitalized comments it also pulled the literal url along with it. Since I had some free time, I figured I'd take a stab at helping reduce this issue. :)

In this PR, I primarily did 2 things-
- Change the formulation of trigger words. Instead of hard-coding them all in there directly, I just set them as your 3 main phrases (what, wut, and wat) and then appended a list with the question mark at the end of each word. It's a bit easier to understand this in-context, so here's the code directly-

``` python
Triggers = ['what', 'wut', 'wat']
Triggers += list(word + '?' for word in Triggers)
```
- Change the parseLine function (forgive the typo in the commit message haha) to only capitalize everything that's not in the parenthesis of a reddit markdown url. For example, if we had `[google](http://google.com)`, it wouldn't capitalize the 'http://google.com' component but everything else. Even though this portion of the code may be able to be further improved by someone else, I figured it was a fine solution for the current situation at hand.

In addition, I also removed that copyright (©) symbol since it was giving my compiler grief--but according to [this](http://www.copyright.gov/circs/circ01.pdf) (page 4), it's still legal to use the word "Copyright" in its place.

Overall though, I've really liked your bot after encountering it thus far across reddit and hope to see it advance in the future. :)
